### PR TITLE
fix(bridge): use universal shebang for interceptor

### DIFF
--- a/src/bridge/cbridge/interceptor.sh
+++ b/src/bridge/cbridge/interceptor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uo pipefail
 


### PR DESCRIPTION
This makes sure the interceptor script works regardless of the
environment its running in.
