### PR TITLE
fix(bridge/interceptor): don't hardcode the bash path

### DIFF
--- a/src/bridge/cbridge/interceptor.sh
+++ b/src/bridge/cbridge/interceptor.sh
@@ -67,5 +67,5 @@ if [[ "$1" == "-c" && "$2" == "scripts/kconfig/conf "* ]]; then
 	echo "[AUTOKERNEL BRIDGE]"
 	python -c 'import os, json; print(json.dumps({k:v for k,v in os.environ.items()}))'
 else
-	exec /bin/bash "$@"
+	exec "$BASH" "$@"
 fi


### PR DESCRIPTION
Bash exposes the `$BASH` environment variable, which holds the path of
the currently in-use interpreter. We should use that instead of
hardcoding `/bin/bash`
